### PR TITLE
Add stats-url to security specification

### DIFF
--- a/manifest-entry.xsd
+++ b/manifest-entry.xsd
@@ -49,7 +49,7 @@
                                     policies (as described in the annotations in sec:HttpSecurityOptions).
 
                                     Clients SHOULD consult this element before accessing the endpoint given in the
-                                    `url` element (otherwise, their request might be rejected by the server).
+                                    `url` and 'stats-url' elements (otherwise, their request might be rejected by the server).
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:element>


### PR DESCRIPTION
'stats-url' is not mentioned when specifying security. It's confusing, as it's not clear whether 'stats-url' should follow this security requirements or not.